### PR TITLE
Implement MonitorTable

### DIFF
--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -70,6 +70,27 @@ MonitorMap[foo_, values_List, opts : OptionsPattern[]] := Which[
 ];
 
 
+
+Attributes[MonitorTable] = {HoldFirst};
+Options[MonitorTable] = Join[
+	Options[iMonitorMap],
+	Options[monitorDisplay]
+];
+
+MonitorTable[foo_, {i_Symbol, start_, end_, step_: 1}, opts : OptionsPattern[]] := MonitorTable[foo, {i, Range[start, end, step]}, opts];
+
+MonitorTable[foo_, {i_Symbol, values_List}, opts : OptionsPattern[]] := Which[
+	OptionValue["Monitor"],
+	iMonitorMap[
+		Function @@ (Hold[foo] /. i :> With[{eval = Slot[]}, eval /; True]),
+		values,
+		opts
+	],
+	
+	True,
+	Table[foo, {i, values}]
+];
+
 End[];
 
 EndPackage[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -84,4 +84,36 @@ VerificationTest[
 	TestID -> "UpdateInterval-zero-means-repeatedly-called-for-all-inputs"
 ];
 
+VerificationTest[
+	Reap[
+		MonitorTools`MonitorTable[Sow[i]; i^2, {i, 1, 3, 1}]
+	],
+	{{1, 4, 9}, {{1, 2, 3}}},
+	TestID -> "MonitorTable-No-EvaluationLeaks"
+];
+
+VerificationTest[
+	MonitorTools`MonitorTable[i, {i, 1, 3, 2}],
+	{1, 3},
+	TestID -> "MonitorTable-Mirror-Table-with-step"
+];
+
+VerificationTest[
+	MonitorTools`MonitorTable[i, {i, 1, 3}],
+	{1, 2, 3},
+	TestID -> "MonitorTable-Mirror-Table-without-step"
+];
+
+VerificationTest[
+	MonitorTools`MonitorTable[ToUpperCase[i], {i, {"a", "b", "c"}}],
+	{"A", "B", "C"},
+	TestID -> "MonitorTable-Mirror-Table-with-list-of-values"
+];
+
+VerificationTest[
+	MonitorTools`MonitorTable[ToUpperCase[i], {i, CharacterRange["a", "e"]}],
+	{"A", "B", "C", "D", "E"},
+	TestID -> "MonitorTable-Mirror-Table-with-list-of-values-2"
+];
+
 EndTestSection[];


### PR DESCRIPTION
`MonitorTable` is another useful function to make a monitored, abortable variant of `Table`:

```Mathematica
In[128]:= MonitorTable[i, {i, 1, 10}]

Out[128]= {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
```

All forms of Table are supported:
```Mathematica
In[134]:= MonitorTable[Print[i + 1]; i^2, {i, 1, 10, 2}]

During evaluation of In[134]:= 2
During evaluation of In[134]:= 4
During evaluation of In[134]:= 6
During evaluation of In[134]:= 8
During evaluation of In[134]:= 10

Out[134]= {1, 9, 25, 49, 81}
```

```Mathematica
In[132]:= MonitorTable[Print[i]; ToLowerCase[i], {i, CharacterRange["A", "E"]}]

During evaluation of In[132]:= A
During evaluation of In[132]:= B
During evaluation of In[132]:= C
During evaluation of In[132]:= D
During evaluation of In[132]:= E

Out[132]= {"a", "b", "c", "d", "e"}
```