### PR TITLE
Added Abortability to keep finished results

### DIFF
--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -116,4 +116,18 @@ VerificationTest[
 	TestID -> "MonitorTable-Mirror-Table-with-list-of-values-2"
 ];
 
+VerificationTest[
+	MonitorTools`MonitorMap[If[# === "C", Abort[], #]&, CharacterRange["A", "E"]],
+	{"A", "B"},
+	{MonitorTools`MonitorMap::aborted},
+	TestID -> "Abortability"
+];
+
+VerificationTest[
+	MonitorTools`MonitorMap[Abort[]&, CharacterRange["A", "E"]],
+	{},
+	{MonitorTools`MonitorMap::aborted},
+	TestID -> "Abortability-1"
+];
+
 EndTestSection[];


### PR DESCRIPTION
It can be painful if you need to abort a long-running looping construct like `Map` or `Table`, since you will lose all of the accumulated values.
```Mathematica
In[1]:= Map[(Pause[1]; #) &, Range[5]]

Out[1]= $Aborted
```

But with a clever combination of `Reap`, `Sow`, and `CheckAbort`, it isn't too hard to set up support to keep values even when an abort is called with `Abort[]` or Alt + period.

Here's an example where I've hit Alt + period part-way through:
```Mathematica
In[199]:= MonitorMap[(Pause[1]; #) &, Range[5]]

During evaluation of In[199]:= MonitorMap::aborted: Aborted after 3 of 5 (~60% complete)

Out[199]= {1, 2, 3}
```