### PR TITLE
Implement Association Functions

### DIFF
--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -7,6 +7,8 @@ MonitorMap::usage = "MonitorMap[foo, {x_1, x_2, ...}]
 Effectively performs Map[foo, {x_1, x_2, ...}] with a progress bar and other features.";
 MonitorTable::usage = "MonitorTable[foo, ...]
 Effectively performs Table[foo, ...] with a progress bar and other features.";
+MonitorAssociationMap::usage = "MonitorAssociationMap[foo, {x_1, x_2, ...}]
+Effectively performs AssociationMap[foo, ...] with a progress bar and other features";
 
 Begin["`Private`"];
 
@@ -81,10 +83,7 @@ MonitorMap[foo_, values_List, opts : OptionsPattern[]] := Which[
 
 
 Attributes[MonitorTable] = {HoldFirst};
-Options[MonitorTable] = Join[
-	Options[iMonitorMap],
-	Options[monitorDisplay]
-];
+Options[MonitorTable] = Options[MonitorMap];
 
 MonitorTable[foo_, {i_Symbol, start_, end_, step_: 1}, opts : OptionsPattern[]] := MonitorTable[foo, {i, Range[start, end, step]}, opts];
 
@@ -98,6 +97,22 @@ MonitorTable[foo_, {i_Symbol, values_List}, opts : OptionsPattern[]] := Which[
 	
 	True,
 	Table[foo, {i, values}]
+];
+
+Attributes[MonitorAssociationMap];
+Options[MonitorAssociationMap] = Options[MonitorMap];
+MonitorAssociationMap[foo_, values_List, opts: OptionsPattern[]] := Which[
+	OptionValue["Monitor"],
+	With[
+		{
+			results = MonitorMap[foo, values, opts]
+		},
+		AssociationThread[Take[values, Length[results]] -> results]
+	],
+	
+	True,
+	AssociationMap[foo, values]
+	
 ];
 
 End[];

--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -11,6 +11,8 @@ MonitorAssociationMap::usage = "MonitorAssociationMap[foo, {x_1, x_2, ...}]
 Effectively performs AssociationMap[foo, ...] with a progress bar and other features";
 MonitorKeyMap::usage = "MonitorKeyMap[foo, a_Association]
 Effectively performs KeyMap[foo, ...] with a progress bar and other features";
+MonitorApplyAt::usage = "MonitorApplyAt[foo, l_List]
+Effectively performs foo @@@ l with a progress bar and other features";
 
 Begin["`Private`"];
 
@@ -130,6 +132,17 @@ MonitorKeyMap[foo_, a_Association, opts: OptionsPattern[]] := Which[
 	
 	True,
 	AssociationMap[foo, a]
+
+];
+
+Attributes[MonitorApplyAt] = Attributes[MonitorMap];
+Options[MonitorApplyAt] = Options[MonitorMap];
+MonitorApplyAt[foo_, values_, opts: OptionsPattern[]] := Which[
+	OptionValue["Monitor"],
+	MonitorMap[Apply[foo], values, opts],
+	
+	True,
+	f @@@ values
 
 ];
 

--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -13,6 +13,9 @@ MonitorKeyMap::usage = "MonitorKeyMap[foo, a_Association]
 Effectively performs KeyMap[foo, ...] with a progress bar and other features";
 MonitorApplyAt::usage = "MonitorApplyAt[foo, l_List]
 Effectively performs foo @@@ l with a progress bar and other features";
+MonitorKeyValueMap::usage = "MonitorKeyValueMap[foo, a_Association]
+Effectively performs KeyValueMap[foo, a] with a progress bar and other features";
+
 
 Begin["`Private`"];
 
@@ -143,6 +146,17 @@ MonitorApplyAt[foo_, values_, opts: OptionsPattern[]] := Which[
 	
 	True,
 	f @@@ values
+
+];
+
+Attributes[MonitorKeyValueMap] = Attributes[MonitorMap];
+Options[MonitorKeyValueMap] = Options[MonitorMap];
+MonitorKeyValueMap[foo_, a_Association, opts: OptionsPattern[]] := Which[
+	OptionValue["Monitor"],
+	MonitorMap[Apply[foo], Normal[a], opts],
+	
+	True,
+	KeyValueMap[f, values]
 
 ];
 

--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -9,6 +9,8 @@ MonitorTable::usage = "MonitorTable[foo, ...]
 Effectively performs Table[foo, ...] with a progress bar and other features.";
 MonitorAssociationMap::usage = "MonitorAssociationMap[foo, {x_1, x_2, ...}]
 Effectively performs AssociationMap[foo, ...] with a progress bar and other features";
+MonitorKeyMap::usage = "MonitorKeyMap[foo, a_Association]
+Effectively performs KeyMap[foo, ...] with a progress bar and other features";
 
 Begin["`Private`"];
 
@@ -21,7 +23,7 @@ Options[iMonitorMap] = {
 	TrackedSymbols -> {},
 	"ProgressMessageFunction" -> (""&)
 };
-iMonitorMap[foo_, values_List, opts : OptionsPattern[]] := Module[
+iMonitorMap[foo_, values_, opts : OptionsPattern[]] := Module[
 	{v, counter, sowTag},
 	counter = 0;
 	Monitor[
@@ -99,7 +101,7 @@ MonitorTable[foo_, {i_Symbol, values_List}, opts : OptionsPattern[]] := Which[
 	Table[foo, {i, values}]
 ];
 
-Attributes[MonitorAssociationMap];
+Attributes[MonitorAssociationMap] = Attributes[MonitorMap];
 Options[MonitorAssociationMap] = Options[MonitorMap];
 MonitorAssociationMap[foo_, values_List, opts: OptionsPattern[]] := Which[
 	OptionValue["Monitor"],
@@ -113,6 +115,22 @@ MonitorAssociationMap[foo_, values_List, opts: OptionsPattern[]] := Which[
 	True,
 	AssociationMap[foo, values]
 	
+];
+
+Attributes[MonitorKeyMap] = Attributes[MonitorMap];
+Options[MonitorKeyMap] = Options[MonitorMap];
+MonitorKeyMap[foo_, a_Association, opts: OptionsPattern[]] := Which[
+	OptionValue["Monitor"],
+	With[
+		{
+			modifiedKeys = MonitorMap[foo, Keys[a], opts]
+		},
+		AssociationThread[modifiedKeys -> Take[Values[a], Length[modifiedKeys]]]
+	],
+	
+	True,
+	AssociationMap[foo, a]
+
 ];
 
 End[];

--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -7,7 +7,7 @@ MonitorMap::usage = "MonitorMap[foo, {x_1, x_2, ...}]
 Effectively performs Map[foo, {x_1, x_2, ...}] with a progress bar and other features.";
 MonitorTable::usage = "MonitorTable[foo, ...]
 Effectively performs Table[foo, ...] with a progress bar and other features.";
-MonitorAssociationMap::usage = "MonitorAssociationMap[foo, {x_1, x_2, ...}]
+MonitorAssociationMap::usage = "MonitorAssociationMap[foo, ...]
 Effectively performs AssociationMap[foo, ...] with a progress bar and other features";
 MonitorKeyMap::usage = "MonitorKeyMap[foo, a_Association]
 Effectively performs KeyMap[foo, ...] with a progress bar and other features";
@@ -108,13 +108,20 @@ MonitorTable[foo_, {i_Symbol, values_List}, opts : OptionsPattern[]] := Which[
 
 Attributes[MonitorAssociationMap] = Attributes[MonitorMap];
 Options[MonitorAssociationMap] = Options[MonitorMap];
-MonitorAssociationMap[foo_, values_List, opts: OptionsPattern[]] := Which[
+MonitorAssociationMap[foo_, values_, opts : OptionsPattern[]] := Which[
 	OptionValue["Monitor"],
-	With[
-		{
-			results = MonitorMap[foo, values, opts]
-		},
-		AssociationThread[Take[values, Length[results]] -> results]
+	Switch[Head[values],
+		
+		Association,
+		Association @ MonitorMap[foo, Normal[values], opts],
+		
+		_,
+		With[
+			{
+				results = MonitorMap[foo, values, opts]
+			},
+			AssociationThread[Take[values, Length[results]] -> results]
+		]
 	],
 	
 	True,

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -156,4 +156,17 @@ VerificationTest[
 	TestID -> "MonitorKeyMap-Abortability"
 ];
 
+VerificationTest[
+	MonitorTools`MonitorApplyAt[f, {"A" -> 1, "B" -> 2, "C" -> 3}],
+	{f["A", 1], f["B", 2], f["C", 3]},
+	TestID -> "MonitorApplyAt-Mirror-ApplyAt"
+];
+
+VerificationTest[
+	MonitorTools`MonitorApplyAt[If[#1 === "B", Abort[], f[##]]&, {"A" -> 1, "B" -> 2, "C" -> 3}],
+	{f["A", 1]},
+	{MonitorTools`MonitorMap::aborted},
+	TestID -> "MonitorApplyAt-Abortability"
+];
+
 EndTestSection[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -130,4 +130,17 @@ VerificationTest[
 	TestID -> "Abortability-1"
 ];
 
+VerificationTest[
+	MonitorTools`MonitorAssociationMap[f, {1, 2, 3}],
+	<| 1 -> f[1], 2 -> f[2], 3 -> f[3]|>,
+	TestID -> "MonitorAssociationMap-Mirror-AssociationMap"
+];
+
+VerificationTest[
+	MonitorTools`MonitorAssociationMap[If[# === 2, Abort[], f[#]]&, {1, 2, 3}],
+	<| 1 -> f[1]|>,
+	{MonitorTools`MonitorMap::aborted},
+	TestID -> "MonitorAssociationMap-Abortability"
+];
+
 EndTestSection[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -169,4 +169,17 @@ VerificationTest[
 	TestID -> "MonitorApplyAt-Abortability"
 ];
 
+VerificationTest[
+	MonitorTools`MonitorKeyValueMap[f, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	{f["A", 1], f["B", 2], f["C", 3]},
+	TestID -> "MonitorKeyValueMap-Mirror-KeyValueMap"
+];
+
+VerificationTest[
+	MonitorTools`MonitorKeyValueMap[If[#1 === "B", Abort[], f[##]]&, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	{f["A", 1]},
+	{MonitorTools`MonitorMap::aborted},
+	TestID -> "MonitorKeyValueMap-Abortability"
+];
+
 EndTestSection[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -143,4 +143,17 @@ VerificationTest[
 	TestID -> "MonitorAssociationMap-Abortability"
 ];
 
+VerificationTest[
+	MonitorTools`MonitorKeyMap[f, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	<|f["A"] -> 1, f["B"] -> 2, f["C"] -> 3|>,
+	TestID -> "MonitorKeyMap-Mirror-KeyMap"
+];
+
+VerificationTest[
+	MonitorTools`MonitorKeyMap[If[# === "B", Abort[], f[#]]&, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	<|f["A"] -> 1|>,
+	{MonitorTools`MonitorMap::aborted},
+	TestID -> "MonitorKeyMap-Abortability"
+];
+
 EndTestSection[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -133,14 +133,27 @@ VerificationTest[
 VerificationTest[
 	MonitorTools`MonitorAssociationMap[f, {1, 2, 3}],
 	<| 1 -> f[1], 2 -> f[2], 3 -> f[3]|>,
-	TestID -> "MonitorAssociationMap-Mirror-AssociationMap"
+	TestID -> "MonitorAssociationMap-Mirror-AssociationMap-List"
 ];
 
 VerificationTest[
 	MonitorTools`MonitorAssociationMap[If[# === 2, Abort[], f[#]]&, {1, 2, 3}],
 	<| 1 -> f[1]|>,
 	{MonitorTools`MonitorMap::aborted},
-	TestID -> "MonitorAssociationMap-Abortability"
+	TestID -> "MonitorAssociationMap-Abortability-List"
+];
+
+VerificationTest[
+	MonitorTools`MonitorAssociationMap[Reverse, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	<|1 -> "A", 2 -> "B", 3 -> "C"|>,
+	TestID -> "MonitorAssociationMap-Mirror-AssociationMap-Association"
+];
+
+VerificationTest[
+	MonitorTools`MonitorAssociationMap[If[MatchQ[#, Rule[_, 2]], Abort[], Reverse[#]]&, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	<|1 -> "A"|>,
+	{MonitorTools`MonitorMap::aborted},
+	TestID -> "MonitorAssociationMap-Abortability-Association"
 ];
 
 VerificationTest[


### PR DESCRIPTION
There are several looping construction involving `Association`s in the Wolfram Language.
With this PR, I've added monitoring support for these:

#### MonitorAssociationMap

```Mathematica
In[71]:= MonitorAssociationMap[Sin, Range[1, 5]]

Out[71]= <|1 -> Sin[1], 2 -> Sin[2], 3 -> Sin[3], 4 -> Sin[4], 
 5 -> Sin[5]|>
```

```Mathematica
In[77]:= MonitorAssociationMap[Reverse, <|"A" -> 1, "B" -> 2, 
  "C" -> 3|>]

Out[77]= <|1 -> "A", 2 -> "B", 3 -> "C"|>
```

#### MonitorKeyMap
```Mathematica
In[73]:= MonitorKeyMap[f, <|"A" -> 1, "B" -> 2, "C" -> 3|>]

Out[73]= <|f["A"] -> 1, f["B"] -> 2, f["C"] -> 3|>
```

#### MonitorKeyValueMap
```Mathematica
In[74]:= MonitorKeyValueMap[f, <|"A" -> 1, "B" -> 2, "C" -> 3|>]

Out[74]= {f["A", 1], f["B", 2], f["C", 3]}
```

#### MonitorApplyAt
"Apply At" this is the name I call the `@@@` shorthand operator for `Apply[#1, #2, {1}] &`.
```Mathematica
In[76]:= MonitorApplyAt[f, {"A" -> 1, "B" -> 2, "C" -> 3}]

Out[76]= {f["A", 1], f["B", 2], f["C", 3]}
```