### PR TITLE
Implement MonitorSelect and MonitorCases

### DIFF
--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -99,7 +99,7 @@ Options[MonitorMap] = Join[
 	Options[iMonitorMap],
 	Options[monitorDisplay]
 ];
-MonitorMap[foo_, values_List, opts : OptionsPattern[]] := Which[
+MonitorMap[foo_, values_, opts : OptionsPattern[]] := Which[
 	OptionValue["Monitor"],
 	iMonitorMap[foo, values, opts],
 	

--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -16,6 +16,8 @@ Effectively performs foo @@@ l with a progress bar and other features";
 MonitorKeyValueMap::usage = "MonitorKeyValueMap[foo, a_Association]
 Effectively performs KeyValueMap[foo, a] with a progress bar and other features";
 
+MonitorSelect::usage = "MonitorSelect[data, test : Identity, n : Infinity]
+Effectively performs Select[data, test, n] with a progress bar and other features";
 
 Begin["`Private`"];
 
@@ -165,6 +167,33 @@ MonitorKeyValueMap[foo_, a_Association, opts: OptionsPattern[]] := Which[
 	True,
 	KeyValueMap[f, values]
 
+];
+
+Options[MonitorSelect] = Options[MonitorMap];
+MonitorSelect[data_, test_:Identity, n: (_Integer ? Positive | Infinity): Infinity, opts: OptionsPattern[]] := Which[
+	OptionValue["Monitor"],
+	Module[{sowTag, sowCount = 0},
+		Reap[
+			MonitorMap[
+				With[{},
+					If[TrueQ[test[#]],
+						Sow[#, sowTag];
+						sowCount++;
+						If[sowCount >= n,
+							Break[];
+						];
+					];
+				]&,
+				data,
+				opts
+			],
+			sowTag
+		] // Last // Replace[{l_List} :> l]
+	],
+	
+	True,
+	Select[data, test, n]
+	
 ];
 
 End[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -220,5 +220,52 @@ VerificationTest[
 ];
 
 
+VerificationTest[
+	MonitorTools`MonitorCases[{1, {2}, 3}, _Integer],
+	{1, 3},
+	TestID -> "MonitorCases-Two-Arguments-Simple-Pattern"
+];
+
+VerificationTest[
+	MonitorTools`MonitorCases[{{1}, 2, 3}, i_Integer -> "A"],
+	{"A", "A"},
+	TestID -> "MonitorCases-Two-Arguments-Rule-Pattern"
+];
+
+VerificationTest[
+	MonitorTools`MonitorCases[{{1}, 2, 3}, i_Integer :> i^2],
+	{4, 9},
+	TestID -> "MonitorCases-Two-Arguments-RuleDelayed"
+];
+
+VerificationTest[
+	MonitorTools`MonitorCases[List /@ Range[1, 3], _Integer],
+	{},
+	TestID -> "MonitorCases-Two-Arguments-Failure-Case"
+];
+
+VerificationTest[
+	MonitorTools`MonitorCases[List /@ Range[1, 3], _Integer, Infinity],
+	{1, 2, 3},
+	TestID -> "MonitorCases-Three-Arguments"
+];
+
+VerificationTest[
+	MonitorTools`MonitorCases[List /@ Range[1, 3], _String, Infinity],
+	{},
+	TestID -> "MonitorCases-Three-Arguments-FailureCase"
+];
+
+VerificationTest[
+	MonitorTools`MonitorCases[List /@ Range[1, 10], _Integer?EvenQ, Infinity, 3],
+	{2, 4, 6},
+	TestID -> "MonitorCases-Four-Arguments"
+];
+
+VerificationTest[
+	MonitorTools`MonitorCases[List /@ Range[1, 10], _String, Infinity, 3],
+	{},
+	TestID -> "MonitorCases-Four-Arguments-Failure-Case"
+];
 
 EndTestSection[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -195,4 +195,30 @@ VerificationTest[
 	TestID -> "MonitorKeyValueMap-Abortability"
 ];
 
+VerificationTest[
+	MonitorTools`MonitorSelect[Range[1, 10], EvenQ],
+	{2, 4, 6, 8, 10},
+	TestID -> "MonitorSelect-Two-Arguments"
+];
+
+VerificationTest[
+	MonitorTools`MonitorSelect[Range[1, 10], False &],
+	{},
+	TestID -> "MonitorSelect-Two-Arguments-Failure-Case"
+];
+
+VerificationTest[
+	MonitorTools`MonitorSelect[Range[1, 10], EvenQ, 3],
+	{2, 4, 6},
+	TestID -> "MonitorSelect-Three-Arguments"
+];
+
+VerificationTest[
+	MonitorTools`MonitorSelect[Range[1, 10], False &, 3],
+	{},
+	TestID -> "MonitorSelect-Three-Arguments-Failure-Case"
+];
+
+
+
 EndTestSection[];


### PR DESCRIPTION
Sometimes, it's nice to run `Select` or `Cases` over a large dataset and be able to tell how long it will take to complete the search.
With the changes in the PR, I've added such functionality.

In the future, it would be nice to add the capability to see how many have been found so far as well, but this will likely take more effort to set up and optimize, etc....

### MonitorSelect
```Mathematica
In[111]:= MonitorSelect[Range[1, 10], EvenQ]

Out[111]= {2, 4, 6, 8, 10}
```

### MonitorCases
```Mathematica
In[12]:= MonitorCases[List /@ List /@ Range[1, 10],  i_Integer?EvenQ :> i^2, Infinity]

Out[12]= {4, 16, 36, 64, 100}
```