### PR TITLE
Implement MonitorTestReport

### DIFF
--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -273,8 +273,13 @@ Options[MonitorTestReport] = Join[Options[MonitorMap], Options[TestReport]];
 MonitorTestReport[fileName_String, opts: OptionsPattern[]] :=
 	iMonitorTestReport[fileName, opts];
 
-MonitorTestReport[tests: {(Inactive[VerificationTest][__] | _VerificationTest)..}, opts:OptionsPattern[]] :=
+MonitorTestReport[tests: {(Inactive[VerificationTest][__])..}, opts:OptionsPattern[]] :=
     iMonitorTestReport[tests, opts];
+
+MonitorTestReport[tests: {VerificationTest__}, opts:OptionsPattern[]] := With[
+	{inactivatedTests = List @@ Inactivate[tests]},
+	iMonitorTestReport[inactivatedTests, opts]
+];
 
 MonitorTestReport[x_, rest___] := iMonitorTestReport[Evaluate @ x, rest];
 

--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -35,7 +35,7 @@ Options[iMonitorMap] = {
 	TrackedSymbols -> {},
 	"ProgressMessageFunction" -> (""&)
 };
-iMonitorMap[foo_, values_, opts : OptionsPattern[]] := Module[
+iMonitorMap[foo_, values_List, opts : OptionsPattern[]] := Module[
 	{
 		v, counter, sowTag,
 		progressMessageFunction, progressMessageFunctionArguments, passCurrentValueQ,
@@ -96,6 +96,13 @@ iMonitorMap[foo_, values_, opts : OptionsPattern[]] := Module[
 		OptionValue["DisplayThreshold"]
 	]
 ];
+
+iMonitorMap[foo_, a_Association, opts___] := With[
+	{values = MonitorMap[foo, Values[a], opts]},
+	AssociationThread[Take[Keys[a], Length[values]], values]
+];
+
+iMonitorMap[foo_, x_, opts___] := Head[x] @@ MonitorMap[foo, List @@ x, opts];
 
 Options[MonitorMap] = Join[
 	Options[iMonitorMap],

--- a/MonitorTools.wl
+++ b/MonitorTools.wl
@@ -5,6 +5,8 @@ BeginPackage["MonitorTools`"];
 
 MonitorMap::usage = "MonitorMap[foo, {x_1, x_2, ...}]
 Effectively performs Map[foo, {x_1, x_2, ...}] with a progress bar and other features.";
+MonitorMapIndexed::usage = "MonitorMapIndexed[foo, {x_1, x_2}]
+Effectively performs MonitorMapIndexed[foo, {x_1, x_2, ...}] with a progress bar and other features.";
 MonitorTable::usage = "MonitorTable[foo, ...]
 Effectively performs Table[foo, ...] with a progress bar and other features.";
 MonitorAssociationMap::usage = "MonitorAssociationMap[foo, ...]
@@ -108,6 +110,20 @@ MonitorMap[foo_, values_, opts : OptionsPattern[]] := Which[
 ];
 
 
+Options[MonitorMapIndexed] = Options[MonitorMap];
+MonitorMapIndexed[foo_, values_, opts : OptionsPattern[]] := Which[
+	OptionValue["Monitor"],
+	iMonitorMapIndexed[foo, values, opts],
+	
+	True,
+	MapIndexed[foo, values]
+];
+
+iMonitorMapIndexed[foo_, values_, opts___] :=
+	Head[values] @@ MonitorApplyAt[foo, Transpose[{List @@ values, List /@ Range[Length[values]]}], opts];
+
+iMonitorMapIndexed[foo_, values_Association, opts___] :=
+    Association @ MonitorKeyValueMap[#1 -> foo[#2, {Key[#1]}]&, values, opts];
 
 Attributes[MonitorTable] = {HoldFirst};
 Options[MonitorTable] = Options[MonitorMap];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -312,4 +312,19 @@ VerificationTest[
 	SameTest -> MatchQ
 ];
 
+VerificationTest[
+	Module[{sowTag},
+		Reap[
+			MonitorTestReport[
+				{
+					VerificationTest[Sow[1, sowTag]; 1 + 2, 3],
+					VerificationTest[Sow[2, sowTag]; 2 + 2, 4]
+				}
+			]
+		][[-1, 1]]
+	],
+	{1, 2},
+	TestID -> "MonitorTestReport-no-evaluation-leaks"
+];
+
 EndTestSection[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -13,6 +13,18 @@ VerificationTest[
 ];
 
 VerificationTest[
+	MonitorTools`MonitorMap[foo, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	<|"A" -> foo[1], "B" -> foo[2], "C" -> foo[3]|>,
+	TestID -> "Mirror-Map-Association"
+];
+
+VerificationTest[
+	MonitorTools`MonitorMap[Sin, blah[1, 2, 3]],
+	blah[Sin[1], Sin[2], Sin[3]],
+	TestID -> "Mirror-Map-Association"
+];
+
+VerificationTest[
 	Reap[
 		MonitorTools`MonitorMap[
 			Identity,

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -268,4 +268,22 @@ VerificationTest[
 	TestID -> "MonitorCases-Four-Arguments-Failure-Case"
 ];
 
+VerificationTest[
+	MonitorMapIndexed[foo, CharacterRange["A", "E"]],
+	{foo["A", {1}], foo["B", {2}], foo["C", {3}], foo["D", {4}], foo["E", {5}]},
+	TestID -> "MonitorMapIndexed-List"
+];
+
+VerificationTest[
+	MonitorMapIndexed[foo, blah @@ CharacterRange["A", "E"]],
+	blah[foo["A", {1}], foo["B", {2}], foo["C", {3}], foo["D", {4}], foo["E", {5}]],
+	TestID -> "MonitorMapIndexed-arbitrary-head"
+];
+
+VerificationTest[
+	MonitorMapIndexed[foo, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	<|"A" -> foo[1, {Key["A"]}], "B" -> foo[2, {Key["B"]}], "C" -> foo[3, {Key["C"]}]|>,
+	TestID -> "MonitorMapIndexed-Association"
+];
+
 EndTestSection[];

--- a/MonitorTools.wlt
+++ b/MonitorTools.wlt
@@ -293,9 +293,23 @@ VerificationTest[
 ];
 
 VerificationTest[
-	MonitorMapIndexed[foo, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
+	MonitorTools`MonitorMapIndexed[foo, <|"A" -> 1, "B" -> 2, "C" -> 3|>],
 	<|"A" -> foo[1, {Key["A"]}], "B" -> foo[2, {Key["B"]}], "C" -> foo[3, {Key["C"]}]|>,
 	TestID -> "MonitorMapIndexed-Association"
+];
+
+VerificationTest[
+	MonitorTools`MonitorTestReport["SimpleTestSuite.wlt"],
+	_TestReportObject,
+	TestID -> "MonitorTestReport-File",
+	SameTest -> MatchQ
+];
+
+VerificationTest[
+	MonitorTools`MonitorTestReport[{VerificationTest[1 + 2, 3], VerificationTest[2 + 2, 4]}],
+	_TestReportObject,
+	TestID -> "MonitorTestReport-VerificationTest-List",
+	SameTest -> MatchQ
 ];
 
 EndTestSection[];

--- a/SimpleTestSuite.wlt
+++ b/SimpleTestSuite.wlt
@@ -1,0 +1,22 @@
+BeginTestSection["SimpleTestSuite"];
+
+VerificationTest[
+	1 + 1,
+	2,
+	TestID -> "passing-test-1"
+];
+
+VerificationTest[
+	2 + 2,
+	4,
+	TestID -> "passing-test-2"
+];
+
+VerificationTest[
+	3 + 3,
+	6,
+	TestID -> "passing-test-3"
+];
+
+
+EndTestSection[];


### PR DESCRIPTION
### Bug fix: `MonitorMap`
`MonitorMap` now works properly with `Association`:
```Mathematica
In[465]:= MonitorMap[foo, <|"A" -> 1, "B" -> 2, "C" -> 3|>]

Out[465]= <|"A" -> foo[1], "B" -> foo[2], "C" -> foo[3]|>
```

### New: `MonitorMapIndexed`
This is sometimes very useful:
```Mathematica
In[466]:= MonitorMapIndexed[foo, CharacterRange["A", "E"]]

Out[466]= {foo["A", {1}], foo["B", {2}], foo["C", {3}], foo["D", {4}], foo["E", {5}]}
```

It also works with `Association`:
```Mathematica
In[467]:= MonitorMapIndexed[foo, <|"A" -> 1, "B" -> 2, "C" -> 3|>]

Out[467]= <|"A" -> foo[1, {Key["A"]}], "B" -> foo[2, {Key["B"]}], "C" -> foo[3, {Key["C"]}]|>
```

### New: `MonitorTestReport`
Running large test suites can be painful, especially when you have no idea how long they will run.
With `MonitorTestReport`, you can monitor the progress of a test suite with little effort:
```Mathematica
MonitorTestReport[
 {
  VerificationTest[Pause[1]; 1, 1],
  VerificationTest[Pause[2]; 2, 2],
  VerificationTest[Pause[3]; 3, 3]
  }
 ]
```

![image](https://user-images.githubusercontent.com/26029945/40255080-7b3211a6-5aab-11e8-816e-bd1c47e7fc7f.png)

In the future, I'll look into showing the current Test ID or index, as well as how many have failed, succeeded, etc..

Test files can also be run with this function:
```Mathematica
MonitorTestReport["SimpleTestSuite.wlt"]
```